### PR TITLE
Add additional snap interfaces and node build options

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,11 +22,15 @@ apps:
       - pulseaudio
       - removable-media
       - serial-port
+  npm:
+    command: bin/npm
 
 parts:
   red:
     plugin: nodejs
     node-engine: 8.12.0
+    npm-flags:
+      - --unsafe-perm
     stage-packages:
       - gnustep-gui-runtime
       - python

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,10 +13,16 @@ apps:
     plugs:
       - bluez
       - bluetooth-control
+      - camera
+      - gpio
       - home
       - network-bind
       - network
       - network-observe
+      - pulseaudio
+      - removable-media
+      - serial-port
+
 parts:
   red:
     plugin: nodejs

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,8 @@ apps:
     daemon: simple
     restart-condition: on-failure
     plugs:
+      - bluez
+      - bluetooth-control
       - home
       - network-bind
       - network


### PR DESCRIPTION
This pull request exposes `npm` so that node modules can be installed into the writeable common data area inside the snap via `node-red.npm`.

Snap interfaces for common use cases have been added and `--unsafe-perm` build option added for node.