### PR TITLE
snapcraft.yaml: Automate builds and version numbering

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: node-red
-version: 0.19.5
+adopt-info: node-red
 summary: A visual tool for wiring the Internet of Things
 description: >
   Node-RED is a flow based programming application for wiring together hardware
@@ -32,7 +32,11 @@ apps:
       - network
 
 parts:
-  red:
+  node-red-git:
+    plugin: nil
+    source: https://github.com/node-red/node-red.git
+
+  node-red:
     plugin: nodejs
     node-engine: 8.11.2
     npm-flags:
@@ -46,6 +50,10 @@ parts:
       - node-red-node-rbe
       - node-red-node-serialport
       - node-red-node-smooth
+    override-build: |
+      snapcraftctl build
+      VER=$(npm show node-red version)
+      snapcraftctl set-version $VER
   settings:
     plugin: dump
     source: settings


### PR DESCRIPTION
Derive version from the published npm node-red version. Add a source part to trigger daily builds when upstream changes.