### PR TITLE
snap: Bump to core20

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub version](https://badge.fury.io/gh/node-red%2Fnode-red.svg)](https://badge.fury.io/gh/node-red%2Fnode-red)
 
 The Node-RED graphical wiring tool for Low-code programming of event-driven applications.
-Packaged as a Core18 based Ubuntu Snap, intended for multiple architectures.
+Packaged as a Core20 based Ubuntu Snap, intended for multiple architectures.
 
 Listens on port 1880 and runs as as service in strict mode by default.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Low-code programming for event-driven applications
 description: Node-RED is a flow based programming application for wiring together hardware devices, APIs and online services in new and interesting ways. For more information see http://nodered.org
 confinement: strict
 grade: stable
-base: core18
+base: core20
 
 # Limit architectures as ppcel64 doesn't build currently
 architectures:


### PR DESCRIPTION
Core 18 is 4 years old, and while well supported, the it's nearing it's end of life. This change therefor bumps the core to the '20 edition. '22 isn't stabile yet, and thus a jump too big.

This change has been tested on the 22 version of Ubuntu, and works as expected.